### PR TITLE
run apt-get update before installing packages

### DIFF
--- a/packages/python3/packaging
+++ b/packages/python3/packaging
@@ -2,6 +2,7 @@
 
 set -e -x
 
+apt-get update
 apt install -y libffi-dev
 tar xzf Python-3.12.*.tgz
 pushd Python-3.12.*/


### PR DESCRIPTION
## Changes proposed in this pull request:

- Make sure we have an apt cache by running apt-get update, otherwise libffi-dev is not found and the Python package cannot be built

## security considerations

This should increase security by ensuring we're installing the latest versions of packages available from Ubuntu
